### PR TITLE
Use proxy settings for both http and https

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -100,7 +100,7 @@ impl ApiCaller {
             Ok(x) => {
                 if let Some(proxy_cfg) = x {
                     debug!("api::call() -- req: using proxy: {}", proxy_cfg);
-                    client_builder = client_builder.proxy(Proxy::http(format!("http://{}", proxy_cfg).as_str())?);
+                    client_builder = client_builder.proxy(Proxy::all(format!("http://{}", proxy_cfg).as_str())?);
                 }
             }
             Err(_) => {}


### PR DESCRIPTION
Should solve issue turtl/tracker#153

The problem described in the issue is caused because the current code configures the use of a proxy only for HTTP request. However, most (all?) of the requests that are made are HTTPS requests.
