### PR TITLE
Mark carrier_free function as unsafe

### DIFF
--- a/carrier/src/c.rs
+++ b/carrier/src/c.rs
@@ -99,7 +99,7 @@ pub extern fn carrier_recv_nb(channel_c: *const c_char, len_c: *mut usize) -> *c
 }
 
 #[no_mangle]
-pub extern fn carrier_free(msg: *const u8, len: usize) -> i32 {
+pub  unsafe extern fn carrier_free(msg: *const u8, len: usize) -> i32 {
     let vec = unsafe { Vec::from_raw_parts(msg as *mut u8, len, len) };
     drop(vec);
     0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,7 @@ pub mod c_api {
 
     #[no_mangle]
     pub extern fn turtlc_free(msg: *const u8, len: usize) -> i32 {
-        carrier::c::carrier_free(msg, len)
+        unsafe { carrier::c::carrier_free(msg, len) }
     }
 
     #[no_mangle]


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/turtl/core-rs/blob/fd3146aa09377e0a11d5a8873c2da5983a9832a6/carrier/src/c.rs#L102-L106

[https://doc.rust-lang.org/std/vec/struct.Vec.html#method.from_raw_parts](url)
The unsafe function called needs to ensure that the parameter must be:
- ptr must have been allocated using the global allocator, such as via the alloc::alloc function.
- T needs to have the same alignment as what ptr was allocated with. (T having a less strict alignment is not sufficient, the alignment really needs to be equal to satisfy the dealloc requirement that memory must be allocated and deallocated with the same layout.)
- The size of T times the capacity (ie. the allocated size in bytes) needs to be the same size as the pointer was allocated with. (Because similar to alignment, dealloc must be called with the same layout size.)
- length needs to be less than or equal to capacity.
- The first length values must be properly initialized values of type T.
- capacity needs to be the capacity that the pointer was allocated with.
- The allocated size in bytes must be no larger than isize::MAX. See the safety documentation of pointer::offset.

and the developer who calls the carrier_free function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.